### PR TITLE
Add missing includes

### DIFF
--- a/lib/source/FileHelper.h
+++ b/lib/source/FileHelper.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <stddef.h>
 #include <vector>
 
 namespace IBLLib

--- a/lib/source/lib.cpp
+++ b/lib/source/lib.cpp
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <cstring>
 #include <cassert>
+#include <math.h>
 
 #include "format.h"
 


### PR DESCRIPTION
Doesn't build on linux without this for me.

Copy of https://github.com/KhronosGroup/glTF-IBL-Sampler/pull/22, didn't bother trying to cherry pick it because it's 2 lines of includes.